### PR TITLE
add docker-compose file for development db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.6'
+services:
+  db:
+    container_name: memorex-db
+    image: 'postgres'
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: memorex_dev
+    ports:
+      - 5432:5432
+    volumes:
+      - 'pgdata:/var/lib/postgresql/data'
+
+  adminer:
+    container_name: memorex-adminer
+    image: adminer
+    ports:
+      - 8080:8080
+
+volumes:
+  pgdata:


### PR DESCRIPTION
This is handy for those who prefer dockerized postgres rather than maintaining the proper databases on their OS directly.